### PR TITLE
chore: polyfill scroll behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "jest": "^23.6.0",
     "regenerator-runtime": "^0.13.1",
     "rimraf": "^2.6.2"
+  },
+  "dependencies": {
+    "smoothscroll-polyfill": "^0.4.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,4 @@
 import AutoScroll from "./autoscroll";
 import EdgeDetector from "./edge-detector";
+import smoothscroll from 'smoothscroll-polyfill';
+smoothscroll.polyfill();


### PR DESCRIPTION
Older browsers, namely Edge 18 and earlier, don't support the use of `scrollBy` and instead throw errors.

In those cases, say when an item is being dragged from one spot to another and we are trying to automatically scroll a container, dragging will still be fine but scrolling won't happen and an error will be thrown.

Adding the polyfill here means that we now support the intended scroll behavior in those older browser cases.