### PR TITLE
chore: export from index

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,8 @@ import AutoScroll from "./autoscroll";
 import EdgeDetector from "./edge-detector";
 import smoothscroll from 'smoothscroll-polyfill';
 smoothscroll.polyfill();
+
+export default {
+    AutoScroll,
+    EdgeDetector
+}


### PR DESCRIPTION
The `index` should be the entrypoint for consumers but didn't it originally export anything - now it does.