### PR TITLE
Add an onScroll callback

### DIFF
--- a/src/autoscroll.js
+++ b/src/autoscroll.js
@@ -1,10 +1,8 @@
 import EdgeDetector from "./edge-detector";
 
 const AutoScroll = {
-  initialize(options = {}){
-    this.timerId = null;
+  initialize(options = {}) {
     this.setScrollableContainer(options);
-    this.setRecursionDelay(options);
     this.setScrollDistance(options);
 
     this.edgeDetector = new EdgeDetector(options);
@@ -12,20 +10,15 @@ const AutoScroll = {
 
   // Container to scroll in autoScroll event
   // All offsets + threshholds measured from this
-  setScrollableContainer(options){
+  setScrollableContainer(options) {
     // Add guards for type before setting
-    this.scrollableContainer = options.scrollableContainer || document.documentElement;
-  },
-
-  // Milliseconds
-  setRecursionDelay(options){
-    // Add guards for type before setting
-    this.recursionDelay = options.recursionDelay || 50;
+    this.scrollableContainer =
+      options.scrollableContainer || document.documentElement;
   },
 
   // Distance autoScroller should increase scroll, each call
   // Measured in pixels
-  setScrollDistance(options){
+  setScrollDistance(options) {
     // Add guards for type before setting
     this.scrollDistance = options.scrollDistance || 10;
   },
@@ -36,7 +29,6 @@ const AutoScroll = {
     let scrollYBy = 0;
     let scrollXBy = 0;
 
-    clearInterval(self.timerId);
     // Event location in document coordinates
     self.edgeDetector.translateEventCoords(event);
 
@@ -60,20 +52,13 @@ const AutoScroll = {
       scrollXBy = self.scrollDistance;
     }
 
-    clearInterval(self.timerId);
-    self.timerId = setTimeout(function scrollContainer() {
-      clearInterval(self.timerId);
-      self.scrollableContainer.scrollBy(scrollXBy, scrollYBy);
-      self.timerId = setTimeout(scrollContainer, self.recursionDelay);
-    }, self.recursionDelay);
+    self.scrollableContainer.scrollBy(scrollXBy, scrollYBy);
   },
 
   reset() {
-    clearInterval(this.timerId);
-    this.timerId = null;
-    this.scrollableContainer = this.scrollDistance = this.recursionDelay = null;
+    this.scrollableContainer = this.scrollDistance = null;
     delete this.edgeDetector;
-  }
+  },
 };
 
 export default AutoScroll;


### PR DESCRIPTION
Autoscroll controls scroll timing with setTimeout and friends. The caller may want to coordinate with this timing by doing stuff whenever scrolling occurs. The simplest way to support this is to take an optional `onScroll` callback, in which the caller may do whatever they need to do.