### PR TITLE
Revert "Remove debounce logic"

### DIFF
--- a/src/autoscroll.js
+++ b/src/autoscroll.js
@@ -1,8 +1,10 @@
 import EdgeDetector from "./edge-detector";
 
 const AutoScroll = {
-  initialize(options = {}) {
+  initialize(options = {}){
+    this.timerId = null;
     this.setScrollableContainer(options);
+    this.setRecursionDelay(options);
     this.setScrollDistance(options);
 
     this.edgeDetector = new EdgeDetector(options);
@@ -10,15 +12,20 @@ const AutoScroll = {
 
   // Container to scroll in autoScroll event
   // All offsets + threshholds measured from this
-  setScrollableContainer(options) {
+  setScrollableContainer(options){
     // Add guards for type before setting
-    this.scrollableContainer =
-      options.scrollableContainer || document.documentElement;
+    this.scrollableContainer = options.scrollableContainer || document.documentElement;
+  },
+
+  // Milliseconds
+  setRecursionDelay(options){
+    // Add guards for type before setting
+    this.recursionDelay = options.recursionDelay || 50;
   },
 
   // Distance autoScroller should increase scroll, each call
   // Measured in pixels
-  setScrollDistance(options) {
+  setScrollDistance(options){
     // Add guards for type before setting
     this.scrollDistance = options.scrollDistance || 10;
   },
@@ -29,6 +36,7 @@ const AutoScroll = {
     let scrollYBy = 0;
     let scrollXBy = 0;
 
+    clearInterval(self.timerId);
     // Event location in document coordinates
     self.edgeDetector.translateEventCoords(event);
 
@@ -52,13 +60,20 @@ const AutoScroll = {
       scrollXBy = self.scrollDistance;
     }
 
-    self.scrollableContainer.scrollBy(scrollXBy, scrollYBy);
+    clearInterval(self.timerId);
+    self.timerId = setTimeout(function scrollContainer() {
+      clearInterval(self.timerId);
+      self.scrollableContainer.scrollBy(scrollXBy, scrollYBy);
+      self.timerId = setTimeout(scrollContainer, self.recursionDelay);
+    }, self.recursionDelay);
   },
 
   reset() {
-    this.scrollableContainer = this.scrollDistance = null;
+    clearInterval(this.timerId);
+    this.timerId = null;
+    this.scrollableContainer = this.scrollDistance = this.recursionDelay = null;
     delete this.edgeDetector;
-  },
+  }
 };
 
 export default AutoScroll;

--- a/test/autoscroll.test.js
+++ b/test/autoscroll.test.js
@@ -1,8 +1,8 @@
-import AutoScroll from "../src/autoscroll";
+import AutoScroll   from "../src/autoscroll";
 import EdgeDetector from "../src/edge-detector";
-jest.mock("../src/edge-detector");
+jest.mock('../src/edge-detector');
 
-describe("AutoScroll", () => {
+describe('AutoScroll', () => {
   beforeEach(() => {
     EdgeDetector.mockClear();
   });
@@ -21,6 +21,10 @@ describe("AutoScroll", () => {
         expect(AutoScroll.scrollableContainer).toBe(document.documentElement);
       });
 
+      it("sets the default recursionDelay to 50 ms", () => {
+        expect(AutoScroll.recursionDelay).toBe(50);
+      });
+
       it("sets the default scrollDistance to 10 (pixels)", () => {
         expect(AutoScroll.scrollDistance).toBe(10);
       });
@@ -31,13 +35,15 @@ describe("AutoScroll", () => {
     });
 
     describe("with options specified", () => {
-      let scrollContainer, distanceVal, options;
+      let scrollContainer, recursionVal, distanceVal, options;
       beforeEach(() => {
         scrollContainer = "Yo dawg I heard you like scrollin";
+        recursionVal = "We put a scroll in your scroll";
         distanceVal = "So you can scroll while you scroll";
         options = {
           scrollableContainer: scrollContainer,
-          scrollDistance: distanceVal,
+          recursionDelay: recursionVal,
+          scrollDistance: distanceVal
         };
         AutoScroll.initialize(options);
       });
@@ -47,6 +53,10 @@ describe("AutoScroll", () => {
 
       it("sets the scrollableContainer from options hash", () => {
         expect(AutoScroll.scrollableContainer).toBe(scrollContainer);
+      });
+
+      it("sets the recursionVal from options hash", () => {
+        expect(AutoScroll.recursionDelay).toBe(recursionVal);
       });
 
       it("sets the scrollDistance from options hash", () => {
@@ -79,7 +89,7 @@ describe("AutoScroll", () => {
       beforeEach(() => {
         scrollCont = "Yo dawg I heard you like scrollin";
         options = {
-          scrollableContainer: scrollCont,
+          scrollableContainer: scrollCont
         };
         AutoScroll.setScrollableContainer(options);
       });
@@ -89,6 +99,40 @@ describe("AutoScroll", () => {
 
       it("sets the value of the scrollableContainer to the container argument", () => {
         expect(AutoScroll.scrollableContainer).toBe(scrollCont);
+      });
+    });
+  });
+
+  describe("#setRecursionDelay()", () => {
+    describe("with no recursionDelay specified", () => {
+      let options;
+      beforeEach(() => {
+        options = {};
+        AutoScroll.setRecursionDelay(options);
+      });
+      afterEach(() => {
+        AutoScroll.reset();
+      });
+
+      it("sets the default value of recursionDelay to the default 50 ms", () => {
+        expect(AutoScroll.recursionDelay).toBe(50);
+      });
+    });
+    describe("with a recursionDelay specified", () => {
+      let options, delay;
+      beforeEach(() => {
+        delay = 4444111000;
+        options = {
+          recursionDelay: delay
+        };
+        AutoScroll.setRecursionDelay(options);
+      });
+      afterEach(() => {
+        AutoScroll.reset();
+      });
+
+      it("sets the value of recursionDelay to the delay argument", () => {
+        expect(AutoScroll.recursionDelay).toBe(delay);
       });
     });
   });
@@ -113,7 +157,7 @@ describe("AutoScroll", () => {
       beforeEach(() => {
         distance = 222222212;
         options = {
-          scrollDistance: distance,
+          scrollDistance: distance
         };
         AutoScroll.setScrollDistance(options);
       });
@@ -128,26 +172,40 @@ describe("AutoScroll", () => {
   });
 
   describe("#reset()", () => {
-    let scrollContainer, distanceVal, options, punchline;
+    let scrollContainer, recursionVal, distanceVal, options, punchline;
     beforeEach(() => {
       scrollContainer = "Yo dawg I heard you like scrollin";
+      recursionVal = "We put a scroll in your scroll";
       distanceVal = "So you can scroll while you scroll";
       options = {
         scrollableContainer: scrollContainer,
-        scrollDistance: distanceVal,
+        recursionDelay: recursionVal,
+        scrollDistance: distanceVal
       };
       AutoScroll.initialize(options);
       punchline = "Why did the chicken cross the road?";
+      AutoScroll.timerId = punchline;
     });
 
     afterEach(() => {
       AutoScroll.reset();
     });
 
+    it("resets any timerId set by various timing functions", () => {
+      expect(AutoScroll.timerId).toBe(punchline);
+      AutoScroll.reset();
+      expect(AutoScroll.timerId).toBe(null);
+    });
     it("resets the container values to null", () => {
       expect(AutoScroll.scrollableContainer).toBe(scrollContainer);
       AutoScroll.reset();
       expect(AutoScroll.scrollableContainer).toBe(null);
+    });
+
+    it("resets the recursion values to null", () => {
+      expect(AutoScroll.recursionDelay).toBe(recursionVal);
+      AutoScroll.reset();
+      expect(AutoScroll.recursionDelay).toBe(null);
     });
 
     it("resets the scrollDistance values to null", () => {
@@ -171,11 +229,10 @@ describe("AutoScroll", () => {
           pageX: 10,
           pageY: 20,
           clientX: 5,
-          clientY: 10,
+          clientY: 10
         };
-        const scrollableContainer = { scrollBy: () => {} };
 
-        AutoScroll.initialize({ scrollableContainer });
+        AutoScroll.initialize();
         spyOn(AutoScroll.edgeDetector, "translateEventCoords");
         spyOn(AutoScroll.edgeDetector, "eventWithinThreshholdFromBottom");
         spyOn(AutoScroll.edgeDetector, "eventWithinThreshholdFromTop");
@@ -190,29 +247,19 @@ describe("AutoScroll", () => {
       });
 
       it("translates the event coordinates in the detector", () => {
-        expect(
-          AutoScroll.edgeDetector.translateEventCoords
-        ).toHaveBeenCalledWith(event);
+        expect(AutoScroll.edgeDetector.translateEventCoords).toHaveBeenCalledWith(event);
       });
       it("calls the bottom threshhold check for each scroll event", () => {
-        expect(
-          AutoScroll.edgeDetector.eventWithinThreshholdFromBottom
-        ).toHaveBeenCalled();
+        expect(AutoScroll.edgeDetector.eventWithinThreshholdFromBottom).toHaveBeenCalled();
       });
       it("calls the top threshhold check for each scroll event", () => {
-        expect(
-          AutoScroll.edgeDetector.eventWithinThreshholdFromTop
-        ).toHaveBeenCalled();
+        expect(AutoScroll.edgeDetector.eventWithinThreshholdFromTop).toHaveBeenCalled();
       });
       it("calls the left threshhold check for each scroll event", () => {
-        expect(
-          AutoScroll.edgeDetector.eventWithinThreshholdFromLeft
-        ).toHaveBeenCalled();
+        expect(AutoScroll.edgeDetector.eventWithinThreshholdFromLeft).toHaveBeenCalled();
       });
       it("calls the right threshhold check for each scroll event", () => {
-        expect(
-          AutoScroll.edgeDetector.eventWithinThreshholdFromRight
-        ).toHaveBeenCalled();
+        expect(AutoScroll.edgeDetector.eventWithinThreshholdFromRight).toHaveBeenCalled();
       });
     });
     describe("when the event is UNDEFINED", () => {
@@ -235,29 +282,19 @@ describe("AutoScroll", () => {
       });
 
       it("DOES NOT translate the event coordinates in the detector", () => {
-        expect(
-          AutoScroll.edgeDetector.translateEventCoords
-        ).not.toHaveBeenCalled();
+        expect(AutoScroll.edgeDetector.translateEventCoords).not.toHaveBeenCalled();
       });
       it("DOES NOT call the bottom threshhold check for each scroll event", () => {
-        expect(
-          AutoScroll.edgeDetector.eventWithinThreshholdFromBottom
-        ).not.toHaveBeenCalled();
+        expect(AutoScroll.edgeDetector.eventWithinThreshholdFromBottom).not.toHaveBeenCalled();
       });
       it("DOES NOT call the top threshhold check for each scroll event", () => {
-        expect(
-          AutoScroll.edgeDetector.eventWithinThreshholdFromTop
-        ).not.toHaveBeenCalled();
+        expect(AutoScroll.edgeDetector.eventWithinThreshholdFromTop).not.toHaveBeenCalled();
       });
       it("DOES NOT call the left threshhold check for each scroll event", () => {
-        expect(
-          AutoScroll.edgeDetector.eventWithinThreshholdFromLeft
-        ).not.toHaveBeenCalled();
+        expect(AutoScroll.edgeDetector.eventWithinThreshholdFromLeft).not.toHaveBeenCalled();
       });
       it("DOES NOT calls the right threshhold check for each scroll event", () => {
-        expect(
-          AutoScroll.edgeDetector.eventWithinThreshholdFromRight
-        ).not.toHaveBeenCalled();
+        expect(AutoScroll.edgeDetector.eventWithinThreshholdFromRight).not.toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
Reverts sarahjschultz/autoscroll-without-opinions#10

We've decided that these opinions are worth preserving, lest this library go from `autoscroll-without-opinions` to `just-scroll-without-opinions`. Arguably, the autoscroll is more important than the without opinions, thus, the revert.